### PR TITLE
Add missing default argument nearfield=true

### DIFF
--- a/src/fmm.jl
+++ b/src/fmm.jl
@@ -927,6 +927,7 @@ function fmm!(target_systems::Tuple, target_tree::Tree, source_systems::Tuple, s
     horizontal_pass_verbose::Bool=false,
     reset_target_tree::Bool=true, reset_source_tree::Bool=true,
     nearfield_device::Bool=false,
+    nearfield::Bool=true,
     tune=false, update_target_systems=true, multipole_acceptance=0.5,
     t_source_tree=0.0, t_target_tree=0.0, t_lists=0.0,
     silence_warnings=false,


### PR DESCRIPTION
This is a minor correction.
The `fmm!()` function is missing a default argument `direct=true` without which the case `nearfield_device=true` fails.

Since the `nearfield` variable is only parsed inside the if condition (`if nearfield_device`) in line 1024, it does not usually trigger an error.

 https://github.com/byuflowlab/FastMultipole.jl/blob/895e13fcf2e1be460b80b9ce8e949f833399018e/src/fmm.jl#L1021-L1024