### PR TITLE
Define numtype as an alternative to eltype

### DIFF
--- a/src/compatibility.jl
+++ b/src/compatibility.jl
@@ -67,7 +67,7 @@ function get_previous_influence(system, i)
         @warn "get_previous_influence not overloaded for type $(typeof(system)); relative error prediction will not be used"
         WARNING_FLAG_MAX_INFLUENCE[] = false
     end
-    return zero(eltype(system)), zero(eltype(system))
+    return zero(numtype(system)), zero(numtype(system))
 end
 
 """
@@ -415,7 +415,7 @@ function target_to_buffer(systems::Tuple, target::Bool, sort_index_list=SVector{
 end
 
 function target_to_buffer(system, target::Bool, switch::DerivativesSwitch, sort_index=1:get_n_bodies(system))
-    buffer = allocate_target_buffer(eltype(system), system, switch)
+    buffer = allocate_target_buffer(numtype(system), system, switch)
     target_to_buffer!(buffer, system, target, sort_index)
     return buffer
 end
@@ -465,7 +465,7 @@ function system_to_buffer(systems::Tuple, sort_index_list=SVector{length(systems
 end
 
 function system_to_buffer(system, sort_index=1:get_n_bodies(system))
-    buffer = allocate_source_buffer(eltype(system), system)
+    buffer = allocate_source_buffer(numtype(system), system)
     system_to_buffer!(buffer, system, sort_index)
     return buffer
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -552,7 +552,7 @@ function FastGaussSeidel(target_systems::Tuple, source_systems::Tuple;
     leaf_size = to_vector(leaf_size, length(source_systems))
 
     # create trees
-    TF = promote_type(eltype.(target_systems)...)
+    TF = promote_type(numtype.(target_systems)...)
     switches = DerivativesSwitch(true, true, true, target_systems)
     target_tree = Tree(target_systems, true, switches; expansion_order, leaf_size, shrink, recenter, interaction_list_method)
     switches = DerivativesSwitch(true, true, true, source_systems)

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -12,7 +12,7 @@ function Tree(systems::Tuple, target::Bool, switches, TF=get_type(systems); buff
         # determine float type
         TF = Float32
         for system in systems
-            TF = promote_type(TF, eltype(system))
+            TF = promote_type(TF, numtype(system))
         end
 
         # initialize variables
@@ -172,7 +172,7 @@ function Tree(systems::Tuple, target::Bool, switches, TF=get_type(systems); buff
     return tree
 end
 
-function Tree(system, target::Bool, TF=eltype(system); optargs...)
+function Tree(system, target::Bool, TF=numtype(system); optargs...)
     return Tree((system,), target, TF; optargs...)
 end
 
@@ -228,7 +228,7 @@ end
 function getTF(systems::Tuple)
     TF = Float32
     for system in systems
-        TF = promote_type(TF, eltype(system))
+        TF = promote_type(TF, numtype(system))
     end
     return TF
 end
@@ -244,7 +244,7 @@ function TreeByLevel(systems::Tuple, target::Bool, TF=get_type(systems), switche
         # determine float type
         TF = Float32
         for system in systems
-            TF = promote_type(TF, eltype(system))
+            TF = promote_type(TF, numtype(system))
         end
 
         # initialize variables
@@ -359,9 +359,9 @@ function allocate_source_buffer(TF, system)
 end
 
 function get_type(systems::Tuple)
-    TF = eltype(first(systems))
+    TF = numtype(first(systems))
     for system in systems
-        TF = promote_type(TF, eltype(system))
+        TF = promote_type(TF, numtype(system))
     end
     return TF
 end
@@ -370,6 +370,8 @@ function get_type(target_systems::Tuple, source_systems::Tuple)
     TF = promote_type(get_type(source_systems), get_type(target_systems))
     return TF
 end
+
+numtype(system) = eltype(system)
 
 """
     allocate_buffers(systems::Tuple, target::Bool)


### PR DESCRIPTION
I ran into an issue with FastMultipole expecting to overload `eltype` such that it returns a `Number` type, so I defined a another layer (`numtype`) that the user can overload as opposed to overloading `eltype`. It defaults to `eltype` if the user has not defined `numtype`, so no breaking changes are introduced.


**Motivations**

I am working with a particle field that wraps an array of particle structs and indexes them directly:

```julia
abstract type ElementType end
struct Vortex <: ElementType end
struct Magnetic <: ElementType end

struct Particle{E<:ElementType, R<:Number}
    x::SVector{3, R}
    strength::SVector{3, R}
    width::R
end

struct ParticleField{P<:Particle,
                      R<:Number,
                      ParticleVectorType<:AbstractVector{P},
                      MatrixType<:AbstractMatrix{R},
                      TensorType<:AbstractArray{R}
                      }

    np::Int                                          # Current number of particles in the field
    particles::ParticleVectorType   # Vector of particles
    U::MatrixType                             # Velocity of each particle
    Ju::TensorType                            # Velocity Jacobian at each particle
end

# Define indexing to make it behave like an array
@inline Base.eltype(::Type{<:ParticleField{P}}) where P = P
@inline Base.getindex(pfield::ParticleField, i::Int) = pfield.particles[i]
@inline Base.setindex!(pfield::ParticleField{P}, p::P, i::Int) where P = (pfield.particles[i] = p)
```

In this example, `Base.eltype(::Type{<:ParticleField{P}}) where P = P` is needed to make `ParticleField` iterable over the particles it contains, but this clashes with FastMultipole needing `eltype(::Type{<:ParticleField{P, R}}) where {P<:Particle, R<:Number}` to return `R` as opposed to `P`. 

This pull request makes it such that the user can go around this clash by defining

```julia
FastMultipole.numtype(system::ParticleField{<:Particle, R}) where R = R
```