### PR TITLE
Make usage of TF consistent in tree construction

### DIFF
--- a/src/fmm.jl
+++ b/src/fmm.jl
@@ -289,7 +289,7 @@ function upward_pass_singlethread!(tree::Tree, systems, expansion_order, lamb_he
     upward_pass_singlethread_2!(tree, expansion_order, lamb_helmholtz)
 end
 
-function upward_pass_multithread_1!(source_tree::Tree, systems::Tuple, expansion_order, n_threads)
+function upward_pass_multithread_1!(source_tree::Tree{TF}, systems::Tuple, expansion_order, n_threads) where TF
     
     #--- load balance ---#
 
@@ -328,7 +328,7 @@ function upward_pass_multithread_1!(source_tree::Tree, systems::Tuple, expansion
 
     #--- preallocate memory ---#
 
-    harmonics = [initialize_harmonics(expansion_order) for _ in 1:n_threads]
+    harmonics = [initialize_harmonics(expansion_order, TF) for _ in 1:n_threads]
 
     #--- compute multipole expansion coefficients ---#
 
@@ -624,7 +624,7 @@ end
 
 function downward_pass_singlethread_2!(tree::Tree{TF,<:Any}, systems, expansion_order, lamb_helmholtz, derivatives_switches, gradient_n_m) where TF
 
-    harmonics = initialize_harmonics(expansion_order)
+    harmonics = initialize_harmonics(expansion_order, TF)
     # loop over systems
     for (i_system, system) in enumerate(systems)
         evaluate_local!(system, i_system, tree, harmonics, gradient_n_m, expansion_order, lamb_helmholtz, derivatives_switches)

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -10,7 +10,7 @@ function Tree(systems::Tuple, target::Bool, switches, TF=get_type(systems); buff
         # println("Part I:")
         # @time begin # most time at center_box
         # determine float type
-        TF = Float32
+        # TF = Float32
         for system in systems
             TF = promote_type(TF, numtype(system))
         end
@@ -1384,6 +1384,8 @@ function center_box(systems::Tuple, bodies_indices, TF)
         x_min, x_max, y_min, y_max, z_min, z_max = max_xyz(x_min, x_max, y_min, y_max, z_min, z_max, system, bodies_index)
     end
 
+    x_min, x_max, y_min, y_max, z_min, z_max = TF(x_min), TF(x_max), TF(y_min), TF(y_max), TF(z_min), TF(z_max)
+
     return get_center_box(x_min, x_max, y_min, y_max, z_min, z_max)
 end
 
@@ -1466,6 +1468,8 @@ function source_center_box(systems::Tuple, bodies_indices, TF)
     for (system, bodies_index) in zip(systems, bodies_indices)
         x_min, x_max, y_min, y_max, z_min, z_max = source_max_xyz(x_min, x_max, y_min, y_max, z_min, z_max, system, bodies_index)
     end
+
+    x_min, x_max, y_min, y_max, z_min, z_max = TF(x_min), TF(x_max), TF(y_min), TF(y_max), TF(z_min), TF(z_max)
 
     return get_center_box(x_min, x_max, y_min, y_max, z_min, z_max)
 end


### PR DESCRIPTION
I ran into issues with systems that had different number types (I was using a source system of type Float64 and a target system of type Dual). Following the rabbit hole I realized that TF was not being used in a few places, so I did modifications to make the usage of TF consistent.